### PR TITLE
fix: correct CSS paths for locatorDotsmall and tickerArrow

### DIFF
--- a/main/weatherscan.css
+++ b/main/weatherscan.css
@@ -551,7 +551,7 @@ img#mist-logo {
 .radar-lbar .cities .city .dot {
   position: absolute;
   z-index: 0;
-  background: transparent url(images/assets/locatorDotsmall.png) no-repeat;
+  background: transparent url(images/assets/locatorDotSmall.png) no-repeat;
   background-size: 100% 100%;
 }
 .radar-lbar .cities .city .dot-outline {
@@ -1183,7 +1183,7 @@ img#mist-logo {
     position: absolute;
     top: 900px;
     left: 504px;
-    background-image: url("/images/misc/tickerArrow.png"), linear-gradient(to left, rgba(53,53,53,0) 0, rgba(53,53,53, 1) 39px 100%);
+    background-image: url("/images/assets/tickerArrow.png"), linear-gradient(to left, rgba(53,53,53,0) 0, rgba(53,53,53, 1) 39px 100%);
     z-index: 1;
     height: 41.5px;
 }


### PR DESCRIPTION
## Summary
Fix two CSS path typos in `main/weatherscan.css`:
1. Line 555: `locatorDotsmall.png` → `locatorDotSmall.png` (case mismatch)
2. Line 1186: `/images/misc/tickerArrow.png` → `/images/assets/tickerArrow.png` (wrong directory)

## Testing
- `locatorDotSmall.png` exists in `main/images/assets/`
- `tickerArrow.png` exists in `main/images/assets/`

Fixes #9