### PR TITLE
Remove unused main reference background

### DIFF
--- a/main/weatherscan.css
+++ b/main/weatherscan.css
@@ -347,7 +347,6 @@ img#mist-logo {
   position: absolute;
   width: 1620px;
   height: 1080px;
-  background: url(images/lbarreference9.png);
   background-size: 100% 100%;
   image-rendering: pixelated;
   z-index: 0;


### PR DESCRIPTION
Fixes #10.

Removed the stale background image from #mainreference. That file is not in the repo, and the element is transparent, so this keeps the page from asking for an image it never uses.

Tested locally by starting the app and checking that /weatherscan.css no longer includes lbarreference9.png.