### PR TITLE
Add timezone support.

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const path = require('path');
 const { createProxyMiddleware } = require('http-proxy-middleware');
+const tzlookup = require("@photostructure/tz-lookup");
 const app = express();
 const port = 3000;
 
@@ -20,6 +21,29 @@ app.get('/airports', async (req, res) => {
         res.status(500).json({ error: 'Failed to fetch airport data' });
     }
 })
+
+app.get('/tz', (req, res) => {
+    try {
+        const lat = parseFloat(req.query.lat);
+        const lon = parseFloat(req.query.lon);
+        if (isNaN(lat) || isNaN(lon)) {
+            return res.status(400).json({
+                error: 'invalid'
+            });
+        }
+        const timezone = tzlookup(lat, lon);
+        res.json({
+            lat,
+            lon,
+            timezone
+        });
+    } catch (error) {
+        res.status(500).json({
+            error: 'failed',
+            details: error.message
+        });
+    }
+});
 
 //npm i http-proxy-middleware
 //  ^ THIS IS IMPORTANT ^

--- a/app.js
+++ b/app.js
@@ -24,17 +24,21 @@ app.get('/airports', async (req, res) => {
 
 app.get('/tz', (req, res) => {
     try {
-        const lat = parseFloat(req.query.lat);
-        const lon = parseFloat(req.query.lon);
-        if (isNaN(lat) || isNaN(lon)) {
+        const geocode = req.query.geocode;
+        if (!geocode || typeof geocode !== 'string') {
             return res.status(400).json({
                 error: 'invalid'
             });
         }
+        const parts = geocode.split(',').map(v => parseFloat(v.trim()));
+        if (parts.length !== 2 || parts.some(n => isNaN(n))) {
+            return res.status(400).json({
+                error: 'invalid'
+            });
+        }
+        const [lat, lon] = parts;
         const timezone = tzlookup(lat, lon);
         res.json({
-            lat,
-            lon,
             timezone
         });
     } catch (error) {

--- a/main/js/data.js
+++ b/main/js/data.js
@@ -1,4 +1,5 @@
 var locationChoice = "main"
+let currentTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 var weatherData = {
   alerts: {
     mainLoc: {
@@ -2399,6 +2400,7 @@ function startPrograms() {
   // } catch (error) {
   //   lBarData.radarUnavailable = true
   // }
+  updateTimezoneFromGeocode()
   slideKickOff()
   alignDataMaps()
   createMiniradarCities()
@@ -2408,6 +2410,20 @@ function startPrograms() {
     $('#startup').fadeOut(0);
   }, 10);
 }
+
+async function updateTimezoneFromGeocode() {
+    if (!locationDataHeaders.mainData.alerts.mainLoc) return;
+    try {
+        const res = await fetch(`/tz?${locationDataHeaders.mainData.alerts.mainLoc}`);
+        const data = await res.json();
+        if (data.timezone) {
+            currentTimezone = data.timezone;
+        }
+    } catch (err) {
+        console.error("timezone failed, defaulting to system", err);
+    }
+}
+
 function dataJS() {
   initializeRadars()
   //initializeDataMaps()
@@ -2415,11 +2431,22 @@ function dataJS() {
       preloadRadars(systemSettings.appearanceSettings.startupTime - 3000);
     }, 3000);
   setInterval(function () {
-    var today = new Date();
-    var date = today.toString().replace('01', '1').replace('02', '2').replace('03', '3').replace('04', '4').replace('05', '5').replace('06', '6').replace('07', '7').replace('08', '8').replace('09', '9').slice(4,10).trimRight() 
-    var time = today.toLocaleTimeString('en-US', { hour: 'numeric', hour12: true, minute: 'numeric', second: 'numeric'}).replace(/ /g,' ').toLowerCase().replaceAll(" ", "")
-    var spacer = ((time.length > 7) ? " " : "  ")
-    $('#date-time').text(date + "\n" + time);
+	  const now = new Date()
+	  const formatter = new Intl.DateTimeFormat('en-US', {
+		  timeZone: currentTimezone,
+		  hour: 'numeric',
+		  minute: 'numeric',
+		  second: 'numeric',
+		  hour12: true
+	  });
+	  const dateFormatter = new Intl.DateTimeFormat('en-US', {
+		  timeZone: currentTimezone,
+		  month: 'short',
+		  day: 'numeric'
+	  });
+	  const time = formatter.format(now).toLowerCase().replace(/ /g, '');
+	  const date = dateFormatter.format(now);
+	  $('#date-time').text(date + "\n" + time);
   }, 1000);
   setTimeout(function() {
     startPrograms()

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "dependencies": {
         "@photostructure/tz-lookup": "^11.5.0",
         "express": "^5.1.0",
-        "http-proxy-middleware": "^3.0.5",
-        "tz-lookup": "^6.1.25"
+        "http-proxy-middleware": "^3.0.5"
       }
     },
     "node_modules/@photostructure/tz-lookup": {
@@ -1062,12 +1061,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/tz-lookup": {
-      "version": "6.1.25",
-      "resolved": "https://registry.npmjs.org/tz-lookup/-/tz-lookup-6.1.25.tgz",
-      "integrity": "sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg==",
-      "license": "CC0-1.0"
-    },
     "node_modules/undici-types": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
@@ -1789,11 +1782,6 @@
           }
         }
       }
-    },
-    "tz-lookup": {
-      "version": "6.1.25",
-      "resolved": "https://registry.npmjs.org/tz-lookup/-/tz-lookup-6.1.25.tgz",
-      "integrity": "sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg=="
     },
     "undici-types": {
       "version": "7.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,17 @@
       "name": "weatherscan-v2",
       "version": "1.0.0",
       "dependencies": {
+        "@photostructure/tz-lookup": "^11.5.0",
         "express": "^5.1.0",
-        "http-proxy-middleware": "^3.0.5"
+        "http-proxy-middleware": "^3.0.5",
+        "tz-lookup": "^6.1.25"
       }
+    },
+    "node_modules/@photostructure/tz-lookup": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/@photostructure/tz-lookup/-/tz-lookup-11.5.0.tgz",
+      "integrity": "sha512-0DVFriinZ7TeOnm9ytXeSL3NMFU87ZqMjgbPNkd8LgHFLcPg1BDyM1eewFYs+pPM+62S4fSP9Mtgijmn+6y95w==",
+      "license": "CC0-1.0"
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.16",
@@ -1054,6 +1062,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/tz-lookup": {
+      "version": "6.1.25",
+      "resolved": "https://registry.npmjs.org/tz-lookup/-/tz-lookup-6.1.25.tgz",
+      "integrity": "sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg==",
+      "license": "CC0-1.0"
+    },
     "node_modules/undici-types": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
@@ -1083,6 +1097,11 @@
     }
   },
   "dependencies": {
+    "@photostructure/tz-lookup": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/@photostructure/tz-lookup/-/tz-lookup-11.5.0.tgz",
+      "integrity": "sha512-0DVFriinZ7TeOnm9ytXeSL3NMFU87ZqMjgbPNkd8LgHFLcPg1BDyM1eewFYs+pPM+62S4fSP9Mtgijmn+6y95w=="
+    },
     "@types/http-proxy": {
       "version": "1.17.16",
       "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
@@ -1770,6 +1789,11 @@
           }
         }
       }
+    },
+    "tz-lookup": {
+      "version": "6.1.25",
+      "resolved": "https://registry.npmjs.org/tz-lookup/-/tz-lookup-6.1.25.tgz",
+      "integrity": "sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg=="
     },
     "undici-types": {
       "version": "7.8.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "Weatherscan V2 is a simulated recreation of Weatherscan by The Weather Channel in HTML/CSS/JS, by mist weather media",
   "main": "app.js",
   "dependencies": {
+    "@photostructure/tz-lookup": "^11.5.0",
     "express": "^5.1.0",
-    "http-proxy-middleware": "^3.0.5"
+    "http-proxy-middleware": "^3.0.5",
+    "tz-lookup": "^6.1.25"
   },
   "scripts": {
     "start": "node app.js",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "dependencies": {
     "@photostructure/tz-lookup": "^11.5.0",
     "express": "^5.1.0",
-    "http-proxy-middleware": "^3.0.5",
-    "tz-lookup": "^6.1.25"
+    "http-proxy-middleware": "^3.0.5"
   },
   "scripts": {
     "start": "node app.js",


### PR DESCRIPTION
As of current, the weatherscan simulator does not handle timezones, opting to use the system's local time no matter if the simulator is displaying data for Tokyo, Pyongyang, or any other far away place that is in a different timezone then local time.
This pull request adds handling for timezones, so the clock is correct for the current location.
This does add a dependency on @photostructure/tz-lookup, but it's only 80KB.
I'll open a PR for this same issue on weatherscan-v1 as well, give me a day.