### PR TITLE
the most minor of all minor changes to a readme ever

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Need support beyond the scope of this README? A guide for configuring this simul
 3. Go to `/main/configs` and open `yourConfig.json`.
 4. Line 4 is where your *weather.com*  API key goes. Replace `"YOUR_API_KEY"` with your *weather.com* API key.
 5. Line 5 is where your *mapbox.com*  API key goes. Replace `"YOUR_API_KEY"` with your *mapbox.com* API key.
-6. Line 6 is where your *mapbox.com*  API key goes. Replace `"YOUR_API_KEY"` with your *developer.tomtom.com* API key. (optional, only if you want traffic report)
-7. Line 7 is where your *mapbox.com*  API key goes. Replace `"YOUR_API_KEY"` with your *HERE.com* API key. (optional, only if you want traffic flow)
+6. Line 6 is where your *developer.tomtom.com*  API key goes. Replace `"YOUR_API_KEY"` with your *developer.tomtom.com* API key. (optional, only if you want traffic report)
+7. Line 7 is where your *HERE.com*  API key goes. Replace `"YOUR_API_KEY"` with your *HERE.com* API key. (optional, only if you want traffic flow)
 8. Save your changes to `yourConfig.json` and close it.
 9. In terminal / command prompt within the main directory, run `npm install --production`. This will install all dependencies required to run.
 10. In terminal / command prompt within the main directory, run `npm start`. This will start a local web server, which is required to run the sim.


### PR DESCRIPTION
a spots for API keys were labelled as both mapbox.com and the actual domain in the README. I've fixed that.