### PR TITLE
fix: startup hang — unhandled promise rejections prevent app from loading

### DIFF
--- a/main/js/extras.js
+++ b/main/js/extras.js
@@ -3743,11 +3743,11 @@ function setMainCityBackground(name, state){
 }
 
 async function getCoordsLocID(locID) {
+	if (!locID) return ""
 	var url = "https://api.weather.com/v3/location/point?locid=" + locID + "&language=en-US&format=json&apiKey=" + api_key
-	
-	const data = await $.getJSON(url)
-	
+
 	try {
+		const data = await $.getJSON(url)
 		return String(data.location.latitude) + "," + String(data.location.longitude)
 	} catch (error) {
 		console.error(error)

--- a/main/js/radar.js
+++ b/main/js/radar.js
@@ -620,21 +620,21 @@ async function stopMiniRadar() {
 //i would recommend stopping this 3 seconds before the sim starts
 async function preloadRadars(){
   try {
-    startLocalRadar();
+    await startLocalRadar();
   } catch (error) {
     console.log("startLocalRadar Error")
     console.error(error)
-    weatherData.dopplerUnavailable
+    weatherData.dopplerUnavailable = true
   }
 
   try {
-    startSatRadar();
+    await startSatRadar();
   } catch (error) {
     console.log("startSatRadar Error")
     console.error(error)
-    weatherData.satUnavailable
+    weatherData.satUnavailable = true
   }
-  
+
   try {
     await startMiniRadar(true);
   } catch (error) {
@@ -642,7 +642,7 @@ async function preloadRadars(){
     console.error(error)
     lBarData.radarUnavailable = true
   }
-  
+
   stopMiniRadar();
   stopLocalRadar();
   stopSatRadar();

--- a/main/js/startup.js
+++ b/main/js/startup.js
@@ -237,7 +237,7 @@ requestAnimationFrame(animate);
 
     console.log("warning crawl data", weatherData.crawlAlerts)
 
-    startPrograms()
+    await startPrograms()
 }
 
 //this kicks everything off, it is not a part of startSystem()


### PR DESCRIPTION
Fix unhandled promise rejection in getCoordsLocID() that crashes the startup chain when a locationID is undefined
Add missing await on startPrograms() so errors propagate correctly
Add missing await on startLocalRadar() and startSatRadar() in preloadRadars() so they complete before being stopped
Fix missing = true assignments on weatherData.dopplerUnavailable and weatherData.satUnavailable error flags