### PR TITLE
fix: use relative asset paths so the sim works under a subpath

### DIFF
--- a/main/js/audio.js
+++ b/main/js/audio.js
@@ -149,7 +149,7 @@ class AudioManager {
         if (!systemSettings.audioSettings.narrations) return;
 
         this.playVoice([
-            '/narrations/Local-CurrentConditions_Default1.wav'
+            'narrations/Local-CurrentConditions_Default1.wav'
         ]);
     }
 
@@ -157,7 +157,7 @@ class AudioManager {
         if (!systemSettings.audioSettings.narrations) return;
 
         this.playVoice([
-            '/narrations/Local-TextForecast_Default1.wav'
+            'narrations/Local-TextForecast_Default1.wav'
         ]);
     }
 
@@ -165,7 +165,7 @@ class AudioManager {
         if (!systemSettings.audioSettings.narrations) return;
 
         this.playVoice([
-            '/narrations/Local-DaypartForecast_Default1.wav'
+            'narrations/Local-DaypartForecast_Default1.wav'
         ]);
     }
 
@@ -173,7 +173,7 @@ class AudioManager {
         if (!systemSettings.audioSettings.narrations) return;
 
         this.playVoice([
-            '/narrations/Local-TrafficOverview_Default1.wav'
+            'narrations/Local-TrafficOverview_Default1.wav'
         ]);
     }
 
@@ -181,7 +181,7 @@ class AudioManager {
         if (!systemSettings.audioSettings.narrations) return;
 
         this.playVoice([
-            '/narrations/Local-TrafficFlow_Default1.wav'
+            'narrations/Local-TrafficFlow_Default1.wav'
         ]);
     }
 
@@ -189,7 +189,7 @@ class AudioManager {
         if (!systemSettings.audioSettings.narrations) return;
 
         this.playVoice([
-            '/narrations/Local-RegionalForecastConditions_Default1.wav'
+            'narrations/Local-RegionalForecastConditions_Default1.wav'
         ]);
     }
 
@@ -197,16 +197,16 @@ class AudioManager {
         if (!systemSettings.audioSettings.narrations) return;
 
         this.playVoice([
-            '/narrations/Local-AllergyReport_Default1.wav'
+            'narrations/Local-AllergyReport_Default1.wav'
         ]);
     }
 
     playWarningBeep() {
         this.playVoice([
-            '/narrations/beep.wav',
-            '/narrations/beep.wav',
-            '/narrations/beep.wav',
-            '/narrations/beep.wav'
+            'narrations/beep.wav',
+            'narrations/beep.wav',
+            'narrations/beep.wav',
+            'narrations/beep.wav'
         ]);
     }
 
@@ -214,7 +214,7 @@ class AudioManager {
         if (!systemSettings.audioSettings.narrations) return;
 
         this.playVoice([
-            '/narrations/Local-LocalAirportConditions_Default1.wav'
+            'narrations/Local-LocalAirportConditions_Default1.wav'
         ]);
     }
 
@@ -222,7 +222,7 @@ class AudioManager {
         if (!systemSettings.audioSettings.narrations) return;
 
         this.playVoice([
-            '/narrations/Local-LocalDoppler_Default1.wav'
+            'narrations/Local-LocalDoppler_Default1.wav'
         ]);
     }
     startPlaying(arr, loop = false) {

--- a/main/weatherscan.css
+++ b/main/weatherscan.css
@@ -1183,7 +1183,7 @@ img#mist-logo {
     position: absolute;
     top: 900px;
     left: 504px;
-    background-image: url("/images/misc/tickerArrow.png"), linear-gradient(to left, rgba(53,53,53,0) 0, rgba(53,53,53, 1) 39px 100%);
+    background-image: url("images/misc/tickerArrow.png"), linear-gradient(to left, rgba(53,53,53,0) 0, rgba(53,53,53, 1) 39px 100%);
     z-index: 1;
     height: 41.5px;
 }
@@ -1290,7 +1290,7 @@ its not 1 for 1 code using so i mean i guess its aight
 .city-intro .circle-one {
   position: absolute;
   background-color: rgb(10,10,160,0.4);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 124%; 
   height: 141%;
@@ -1305,7 +1305,7 @@ its not 1 for 1 code using so i mean i guess its aight
 .city-intro .circle-two {
   position: absolute;
   background-color: rgb(255,212,14,0.7);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 145%; 
   height: 166%;
@@ -1320,7 +1320,7 @@ its not 1 for 1 code using so i mean i guess its aight
 .city-intro .circle-three {
   position: absolute;
   background-color: rgb(255,212,14,0.5);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 148%; 
   height: 164%;
@@ -1410,7 +1410,7 @@ its not 1 for 1 code using so i mean i guess its aight
 .upnext .circle-one {
   position: absolute;
   background-color: rgb(10,10,160,0.4);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 124%; 
   height: 141%;
@@ -1423,7 +1423,7 @@ its not 1 for 1 code using so i mean i guess its aight
   display: none;
   position: absolute;
   background-color: rgb(255,212,14,0.7);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 145%; 
   height: 166%;
@@ -1436,7 +1436,7 @@ its not 1 for 1 code using so i mean i guess its aight
   display: none;
   position: absolute;
   background-color: rgb(255,212,14,0.5);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 148%; 
   height: 164%;
@@ -1856,7 +1856,7 @@ its not 1 for 1 code using so i mean i guess its aight
 .radar-overlay {
   position: absolute;
   z-index: 2;
-  background: transparent url(/images/backgrounds/map_banner_bg.png) no-repeat;
+  background: transparent url(images/backgrounds/map_banner_bg.png) no-repeat;
   height: 100%;
   width: 100%;
   background-size: 100% 100%;
@@ -1881,7 +1881,7 @@ its not 1 for 1 code using so i mean i guess its aight
   width: 1620px;
   height: 1080px;
   z-index: 0;
-  background: transparent url(/images/maps/lambert.us.png) no-repeat;
+  background: transparent url(images/maps/lambert.us.png) no-repeat;
   background-size: 100%;
 }
 .blackcover {
@@ -2847,7 +2847,7 @@ position: absolute;
 .traffic-intro .circle-one {
   position: absolute;
   background-color: rgb(214,141,33,0.6);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 124%; 
   height: 141%;
@@ -2860,7 +2860,7 @@ position: absolute;
   display: none;
   position: absolute;
   background-color: rgb(176,121,35,0.9);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 145%; 
   height: 166%;
@@ -2873,7 +2873,7 @@ position: absolute;
   display: none;
   position: absolute;
   background-color: rgb(183,128,50,0.7);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 148%; 
   height: 164%;
@@ -3334,7 +3334,7 @@ position: absolute;
 .travel-intro .circle-one {
   position: absolute;
   background-color: rgb(105,134,198,0.6);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 124%; 
   height: 141%;
@@ -3347,7 +3347,7 @@ position: absolute;
   display: none;
   position: absolute;
   background-color: rgb(105,134,198,0.9);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 145%; 
   height: 166%;
@@ -3360,7 +3360,7 @@ position: absolute;
   display: none;
   position: absolute;
   background-color: rgb(105,134,198,0.7);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 148%; 
   height: 164%;
@@ -3438,13 +3438,13 @@ position: absolute;
     left: 1.5%;;
     z-index: 0;
     scale: 1.6;
-    background: transparent url(/images/maps/lambert.us.travel.png) no-repeat;
+    background: transparent url(images/maps/lambert.us.travel.png) no-repeat;
     background-size: 100%;
 }
 .travel-weather .overlay {
   position: absolute;
   z-index: 1;
-  background: transparent url(/images/backgrounds/map_banner_bg.png) no-repeat;
+  background: transparent url(images/backgrounds/map_banner_bg.png) no-repeat;
   height: 100%;
   width: 100%;
   background-size: 100% 100%;
@@ -3514,7 +3514,7 @@ position: absolute;
 .travel-forecast .overlay {
   position: absolute;
   z-index: 1;
-  background: transparent url(/images/backgrounds/map_banner_bg.png) no-repeat;
+  background: transparent url(images/backgrounds/map_banner_bg.png) no-repeat;
   height: 100%;
   width: 100%;
   background-size: 100% 100%;
@@ -3696,7 +3696,7 @@ position: absolute;
 .airport-intro .circle-one {
   position: absolute;
   background-color: rgb(105,134,198,0.6);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 124%; 
   height: 141%;
@@ -3709,7 +3709,7 @@ position: absolute;
   display: none;
   position: absolute;
   background-color: rgb(105,134,198,0.9);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 145%; 
   height: 166%;
@@ -3722,7 +3722,7 @@ position: absolute;
   display: none;
   position: absolute;
   background-color: rgb(105,134,198,0.7);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 148%; 
   height: 164%;
@@ -4136,7 +4136,7 @@ position: absolute;
 .international-intro .circle-one {
   position: absolute;
   background-color: rgb(156,159,161,0.6);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 124%; 
   height: 141%;
@@ -4149,7 +4149,7 @@ position: absolute;
   display: none;
   position: absolute;
   background-color: rgb(156,159,161,0.9);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 145%; 
   height: 166%;
@@ -4162,7 +4162,7 @@ position: absolute;
   display: none;
   position: absolute;
   background-color: rgb(156,159,161,0.7);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 148%; 
   height: 164%;
@@ -4743,7 +4743,7 @@ position: absolute;
 .golf-intro .circle-one {
   position: absolute;
   background-color: rgb(163,192,87,0.6);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 124%; 
   height: 141%;
@@ -4756,7 +4756,7 @@ position: absolute;
   display: none;
   position: absolute;
   background-color: rgb(47,130,31,0.9);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 145%; 
   height: 166%;
@@ -4769,7 +4769,7 @@ position: absolute;
   display: none;
   position: absolute;
   background-color: rgb(26,100,25,0.7);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 148%; 
   height: 164%;
@@ -5190,7 +5190,7 @@ position: absolute;
 .health-intro .circle-one {
   position: absolute;
   background-color: rgb(11,182,192,0.6);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 124%; 
   height: 141%;
@@ -5203,7 +5203,7 @@ position: absolute;
   display: none;
   position: absolute;
   background-color: rgb(11,182,192,0.9);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 145%; 
   height: 166%;
@@ -5216,7 +5216,7 @@ position: absolute;
   display: none;
   position: absolute;
   background-color: rgb(11,182,192,0.7);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 148%; 
   height: 164%;
@@ -6318,7 +6318,7 @@ img.raysawareness {
 .garden-intro .circle-one {
   position: absolute;
   background-color: rgb(163,192,87,0.6);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 124%; 
   height: 141%;
@@ -6331,7 +6331,7 @@ img.raysawareness {
   display: none;
   position: absolute;
   background-color: rgb(47,130,31,0.9);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 145%; 
   height: 166%;
@@ -6344,7 +6344,7 @@ img.raysawareness {
   display: none;
   position: absolute;
   background-color: rgb(26,100,25,0.7);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 148%; 
   height: 164%;
@@ -7131,7 +7131,7 @@ img.raysawareness {
 .ski-intro .circle-one {
   position: absolute;
   background-color: rgb(136,77,172,0.6);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 124%; 
   height: 141%;
@@ -7144,7 +7144,7 @@ img.raysawareness {
   display: none;
   position: absolute;
   background-color: rgb(136,77,172,0.9);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 145%; 
   height: 166%;
@@ -7157,7 +7157,7 @@ img.raysawareness {
   display: none;
   position: absolute;
   background-color: rgb(136,77,172,0.7);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 148%; 
   height: 164%;
@@ -7594,7 +7594,7 @@ img.raysawareness {
 .beach-intro .circle-one {
   position: absolute;
   background-color: rgb(163,192,87,0.6);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 124%; 
   height: 141%;
@@ -7607,7 +7607,7 @@ img.raysawareness {
   display: none;
   position: absolute;
   background-color: rgb(47,130,31,0.9);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 145%; 
   height: 166%;
@@ -7620,7 +7620,7 @@ img.raysawareness {
   display: none;
   position: absolute;
   background-color: rgb(26,100,25,0.7);
-  -webkit-mask-image: url("/images/assets/ellipsewhite.png");
+  -webkit-mask-image: url("images/assets/ellipsewhite.png");
   -webkit-mask-size: 100% 100%;
   width: 148%; 
   height: 164%;


### PR DESCRIPTION
### What

Makes 52 root-absolute asset paths relative:

| File | Change | Count |
| --- | --- | --- |
| `main/weatherscan.css` | `url(/images/…)` → `url(images/…)` | 39 |
| `main/js/audio.js` | `'/narrations/…'` → `'narrations/…'` | 13 |

### Why

Those paths resolve against the **origin root**, so they only work when the sim is served from the root of a domain. Anywhere it isn't — a GitHub Pages project site, a subdirectory on shared hosting, a reverse proxy mounted under a path — they request e.g. `example.com/narrations/…` instead of `example.com/weatherscan/narrations/…` and 404. That silently kills all narration audio and the `-webkit-mask-image` ellipses.

This also matches what the codebase already does everywhere else. `weatherscan.css` had 103 relative `url(images/…)` refs against these 39 absolute ones, and `audio.js` already used `'music/'` for the music tracks. The 52 changed here were the outliers.

### No behavior change when served from a domain root

Relative CSS `url()` resolves against the stylesheet's location, and `weatherscan.css` sits at the site root — so `images/…` and `/images/…` resolve identically there. Same for the `audio.js` paths against the document base URL.

The diff is mechanically verifiable as slash-removal only: re-adding a leading `/` to all 52 added lines reproduces the 52 removed lines exactly, byte for byte.

### Testing

Deployed to a GitHub Pages project site (served under `/weatherscan-v2/`, i.e. not a domain root):

**Before** — 404s on `/narrations/Local-CurrentConditions_Default1.wav`, `/narrations/beep.wav`, `/images/assets/ellipsewhite.png`, `/images/backgrounds/map_banner_bg.png`, `/images/maps/lambert.us.png`, and others.

**After** — all return 200, zero absolute `url()` left in the served CSS, no local asset errors in console, and the sim boots through to live data.

Also confirmed no regression at a domain root, since the resolved URLs are unchanged there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
