### PR TITLE
Fix blank traffic map when location is unset

### DIFF
--- a/main/js/location.js
+++ b/main/js/location.js
@@ -564,6 +564,19 @@ async function locationJS() {
         systemSettings.systemLocation = systemSettings.mainCity.locationName;
     }
 
+    // Use the main city for the traffic overview when no separate traffic
+    // location has been configured. Empty coordinates otherwise become 0, 0
+    // in Mapbox and render an ocean-only map.
+    if (systemSettings.traffic.locationName == null || String(systemSettings.traffic.locationName).trim() == "") {
+        systemSettings.traffic.locationName = systemSettings.mainCity.locationName;
+    }
+    if (systemSettings.traffic.lat == null || systemSettings.traffic.lat === "" || !Number.isFinite(Number(systemSettings.traffic.lat))) {
+        systemSettings.traffic.lat = systemSettings.mainCity.lat;
+    }
+    if (systemSettings.traffic.lon == null || systemSettings.traffic.lon === "" || !Number.isFinite(Number(systemSettings.traffic.lon))) {
+        systemSettings.traffic.lon = systemSettings.mainCity.lon;
+    }
+
     //system locationname
     $("#startup .locationname").text("location name: " + systemSettings.systemLocation)
 


### PR DESCRIPTION
## Summary

- Fall back to the auto-detected main city when the traffic location name or coordinates are blank.
- Preserve separately configured traffic locations.

## Root cause

Blank traffic coordinates were passed to Mapbox and coerced to longitude/latitude `0, 0`. The traffic overview therefore rendered an ocean-only map instead of local roads.

## Impact

Users who enable the traffic package without separately configuring its location now see traffic conditions for their main city.

## Validation

- `node --check main/js/location.js`
- `git diff --check`
- Browser verification of the traffic overview with auto-detected Corpus Christi: local roads and congestion colors rendered successfully.
