### PR TITLE
Document August 20-21 fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,14 @@
 
 Report bugs and other issues through the repository's Issues tab.
 
+## August 20-21, 2026
+
+- Adjusted the year formatting used by almanac moon-phase API requests.
+- Corrected late-day Spanish forecast headers to display "Pronóstico para mañana."
+- Added support for "Overnight" periods in Coastal Waters Forecast parsing.
+- Fixed tee-time forecasts using the main-city name instead of the configured golf location name.
+- Changed narration and image references to relative paths so the simulator works when hosted under a URL subpath.
+
 ## August 16, 2026
 
 - Fixed double-line location names in the LBar.

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ Report bugs and other issues through the repository's Issues tab.
 - Added support for "Overnight" periods in Coastal Waters Forecast parsing.
 - Fixed tee-time forecasts using the main-city name instead of the configured golf location name.
 - Changed narration and image references to relative paths so the simulator works when hosted under a URL subpath.
+- Updated `http-proxy-middleware` from 3.0.5 to 3.0.7 to address CVE-2026-55603.
 
 ## August 16, 2026
 


### PR DESCRIPTION
## What changed

- Added an August 20–21, 2026 changelog section.
- Documented the moon-phase request, Spanish daypart title, Coastal Waters parsing, tee-time naming, relative asset-path, and dependency security fixes added since the previous changelog cutoff.

## Why

The prior changelog update covered changes only through August 16. Upstream has since added six substantive fixes that were not documented.

## Impact

Documentation only; there are no runtime or configuration changes.

## Validation

- Cross-checked the entry against non-merge commits from `db9cf84` through `d8fb47a`.
- Ran `git diff --check` successfully.
- Confirmed the branch changes only `changelog.txt`.
